### PR TITLE
Added size selector modal and modified size selector

### DIFF
--- a/lib/components/cards/cart_item_card.dart
+++ b/lib/components/cards/cart_item_card.dart
@@ -2,6 +2,7 @@
 import 'package:bid/components/buttons/shopping_buttons.dart';
 import 'package:bid/models/products_model.dart';
 import 'package:bid/themes/custom_colors.dart';
+import 'package:bid/utils/format_helpers.dart';
 import 'package:bid/utils/image_helpers.dart';
 import 'package:bid/utils/ui_helpers.dart';
 import 'package:flutter/material.dart';
@@ -23,10 +24,7 @@ class CartItemCard extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(0),
-        color: Theme
-            .of(context)
-            .colorScheme
-            .cardBackground,
+        color: Theme.of(context).colorScheme.cardBackground,
       ),
       child: Padding(
         padding: const EdgeInsets.all(12.0),
@@ -59,13 +57,16 @@ class CartItemCard extends StatelessWidget {
                     ),
                   ),
                   const SizedBox(height: 4),
+
+                  //Price and quantity
                   Text(
-                    "\$${product.price.toStringAsFixed(2)}",
+                    '${formatPrice(product.price)}',
                     style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                       color: Theme.of(context).colorScheme.textPrimary,
                       fontWeight: FontWeight.bold,
                     ),
                   ),
+
                   const SizedBox(height: 12),
                   _buildProductAttributes(context),
                 ],
@@ -88,8 +89,8 @@ class CartItemCard extends StatelessWidget {
   }
 
   Widget _buildProductAttributes(context) {
-    String size = "M";
     int quantity = product.quantity > 0 ? product.quantity : 1;
+    String? size = product.selectedSize;
 
     return Row(
       children: [

--- a/lib/components/cards/wishlist_item_card.dart
+++ b/lib/components/cards/wishlist_item_card.dart
@@ -1,4 +1,5 @@
 import 'package:bid/components/buttons/shopping_buttons.dart';
+import 'package:bid/components/product_widgets/modal_size_selector.dart';
 import 'package:bid/models/products_model.dart';
 import 'package:bid/themes/custom_colors.dart';
 import 'package:bid/utils/format_helpers.dart';
@@ -68,7 +69,7 @@ class WishlistItemCard extends StatelessWidget {
                   const SizedBox(height: 12),
                   // Add to Cart Button
                   AddToCartButton(
-                    onTap: onAddToCart,
+                    onTap: () => showSizeSelectorModal(context, product),
                     height: 30,
                     fontSize: 10,
                     width: 120,

--- a/lib/components/cart_widgets/add_to_cart_section.dart
+++ b/lib/components/cart_widgets/add_to_cart_section.dart
@@ -8,11 +8,13 @@ import 'package:bid/models/products_model.dart';
 class AddToCartSection extends StatelessWidget {
   final Product product;
   final int quantity;
+  final String? selectedSize;
 
   const AddToCartSection({
     Key? key,
     required this.product,
     required this.quantity,
+    this.selectedSize,
   }) : super(key: key);
 
   @override
@@ -22,7 +24,12 @@ class AddToCartSection extends StatelessWidget {
 
     return AddToCartButton(
       onTap: () {
-        cartService.addToCart(context, product);
+        final productToAdd = product.copyWith(
+          selectedSize: selectedSize,
+          quantity: quantity,
+        );
+
+        cartService.addToCart(context, productToAdd);
       },
       width: double.infinity,
       textColor: textColor,

--- a/lib/components/category_widgets/category_chips.dart
+++ b/lib/components/category_widgets/category_chips.dart
@@ -43,7 +43,7 @@ class CategoryChips extends StatelessWidget {
                 ),
               ),
               child: Text(
-                category.name,
+                category.name.toUpperCase(),
                 style: TextStyle(
                   color: isSelected
                       ? colorScheme.onPrimary

--- a/lib/components/category_widgets/category_item.dart
+++ b/lib/components/category_widgets/category_item.dart
@@ -47,7 +47,7 @@ class CategoryItem extends StatelessWidget {
         ),
         child: Center(
           child: Text(
-            category.name,
+            category.name.toUpperCase(),
             style: TextStyle(
               color: colorScheme.primary,
               fontWeight: FontWeight.bold,
@@ -93,7 +93,7 @@ class CategoryItem extends StatelessWidget {
                 children: [
                   // Category name
                   Text(
-                    category.name,
+                    category.name.toUpperCase(),
                     style: TextStyle(
                       color: colorScheme.primary,
                       fontSize: 18,

--- a/lib/components/common_widgets/featured_carousel.dart
+++ b/lib/components/common_widgets/featured_carousel.dart
@@ -80,18 +80,16 @@ class FeaturedCarousel extends StatelessWidget {
         ? collectionImage
         : getImageUrl(product.imageUrl);
 
-    final colorScheme = Theme
-        .of(context)
-        .colorScheme;
-    final textTheme = Theme
-        .of(context)
-        .textTheme;
+    final textTheme = Theme.of(context).textTheme;
+    const Color titleColor = Colors.white;
+    const Color descriptionColor = Color(0xDDFFFFFF);
+    const Color buttonTextColor = Colors.white;
+    const Color buttonBorderColor = Colors.white;
 
     return Container(
       height: 400,
       margin: const EdgeInsets.symmetric(horizontal: 10.0),
       decoration: BoxDecoration(
-        color: colorScheme.cardBackground,
         borderRadius: BorderRadius.circular(0),
         image: DecorationImage(
           image: NetworkImage(imageUrl),
@@ -110,14 +108,6 @@ class FeaturedCarousel extends StatelessWidget {
             child: Container(
               padding: const EdgeInsets.all(15),
               decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.bottomCenter,
-                  end: Alignment.topCenter,
-                  colors: [
-                    colorScheme.background,
-                    Colors.transparent,
-                  ],
-                ),
                 borderRadius: BorderRadius.circular(0)
               ),
               child: Column(
@@ -126,7 +116,7 @@ class FeaturedCarousel extends StatelessWidget {
                   Text(
                     collectionName,
                     style: textTheme.headlineSmall?.copyWith(
-                      color: colorScheme.textPrimary,
+                      color: titleColor,
                       fontWeight: FontWeight.bold,
                     ),
                   ),
@@ -134,7 +124,7 @@ class FeaturedCarousel extends StatelessWidget {
                   Text(
                     'Shop the latest collection',
                     style: textTheme.bodyMedium?.copyWith(
-                      color: colorScheme.textSecondary,
+                      color: descriptionColor,
                     ),
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
@@ -153,13 +143,13 @@ class FeaturedCarousel extends StatelessWidget {
                         vertical: 8,
                       ),
                       decoration: BoxDecoration(
-                        border: Border.all(color: colorScheme.accent),
+                        border: Border.all(color: buttonBorderColor),
                         borderRadius: BorderRadius.circular(0),
                       ),
                       child: Text(
                         'SHOP NOW',
                         style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                          color: colorScheme.accent,
+                          color: buttonTextColor,
                           fontWeight: FontWeight.bold,
                         ),
                       ),

--- a/lib/components/home_widgets/hero_section.dart
+++ b/lib/components/home_widgets/hero_section.dart
@@ -17,8 +17,13 @@ class HeroSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
+
+    //Fixed colors so they display the same on the image
+    const Color titleColor = Colors.white;
+    const Color descriptionColor = Color(0xDDFFFFFF);
+    const Color buttonTextColor = Colors.white;
+    const Color buttonBorderColor = Colors.white;
 
     return Stack(
       children: [
@@ -61,7 +66,7 @@ class HeroSection extends StatelessWidget {
                 "THE BID JOURNEY",
                 style: textTheme.titleLarge?.copyWith
                   (
-                  color: colorScheme.primary,
+                  color: titleColor,
                   fontWeight: FontWeight.bold,
                   letterSpacing: 1.5,
                 ),
@@ -71,25 +76,31 @@ class HeroSection extends StatelessWidget {
               Text(
                 "Discover our new collection",
                 style: textTheme.bodyLarge?.copyWith(
-                  color: colorScheme.primary, // Using opacity instead of Colors.white70
+                  color: descriptionColor, // Using opacity instead of Colors.white70
                 ),
               ),
               const SizedBox(height: 20),
 
-              ElevatedButton(
-                onPressed: onShopNowPressed,
-                style: ElevatedButton.styleFrom(
-                  shape: RoundedRectangleBorder(
+              GestureDetector(
+                onTap: onShopNowPressed,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 20,
+                    vertical: 12,
+                  ),
+                  decoration: BoxDecoration(
+                    border: Border.all(color: buttonBorderColor),
                     borderRadius: BorderRadius.circular(0),
                   ),
-                ),
                 child: const Text(
                   "SHOP NOW",
                   style: TextStyle(
+                    color: buttonTextColor,
                     fontWeight: FontWeight.bold,
                     letterSpacing: 1.0,
                   ),
                 ),
+              ),
               ),
             ],
           ),

--- a/lib/components/home_widgets/newsletter_section.dart
+++ b/lib/components/home_widgets/newsletter_section.dart
@@ -24,8 +24,8 @@ class NewsletterSection extends StatelessWidget {
         children: [
           Text(
             title,
-            style: const TextStyle(
-              color: Colors.white,
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.primary,
               fontSize: 18,
               fontWeight: FontWeight.bold,
               letterSpacing: 1.0,
@@ -35,8 +35,8 @@ class NewsletterSection extends StatelessWidget {
           const SizedBox(height: 10),
           Text(
             subtitle,
-            style: const TextStyle(
-              color: Colors.white70,
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.primary,
               fontSize: 14,
               height: 1.5,
             ),

--- a/lib/components/product_widgets/modal_size_selector.dart
+++ b/lib/components/product_widgets/modal_size_selector.dart
@@ -1,0 +1,111 @@
+import 'package:bid/components/buttons/shopping_buttons.dart';
+import 'package:bid/models/products_model.dart';
+import 'package:bid/providers/shop_provider.dart';
+import 'package:bid/services/dialog_service.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+void showSizeSelectorModal(BuildContext context, Product product) {
+  final List<String> sizes = ['XS', 'S', 'M', 'L', 'XL',];
+  String? selectedSize;
+  final colorScheme = Theme.of(context).colorScheme;
+
+  showModalBottomSheet(
+    context: context,
+    backgroundColor: colorScheme.surface,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+    ),
+    builder: (BuildContext context) {
+      return StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return Padding(
+            padding: const EdgeInsets.all(10.0),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      'Select Size',
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                        color: colorScheme.secondary,
+                      ),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.close),
+                      onPressed: () => Navigator.pop(context),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 20),
+                Wrap(
+                  spacing: 10,
+                  runSpacing: 10,
+                  children: sizes.map((size) {
+                    final isSelected = selectedSize == size;
+                    return GestureDetector(
+                      onTap: () {
+                        setState(() {
+                          selectedSize = size;
+                        });
+                      },
+                      child: Container(
+                        width: 60,
+                        height: 60,
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: isSelected
+                              ? colorScheme.primary
+                              : Colors.transparent,
+                          border: Border.all(
+                            color: colorScheme.primary,
+                            width: 1,
+                          ),
+                        ),
+                        child: Center(
+                          child: Text(
+                            size,
+                            style: TextStyle(
+                              color: isSelected
+                                  ? colorScheme.onPrimary
+                                  : colorScheme.primary,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                      ),
+                    );
+                  }).toList(),
+                ),
+                const SizedBox(height: 20),
+                SizedBox(
+                  width: double.infinity,
+                  child: AddToCartButton(
+                    onTap: selectedSize == null ? null : () {
+                      // Add to cart with selected size
+                      final productWithSize = product.copyWith(
+                        selectedSize: selectedSize,
+                      );
+                      context.read<Shop>().addToCart(productWithSize);
+                      DialogService.showAddToCartDialog(context, productWithSize);
+                      Navigator.pop(context);
+                    },
+                    height: 50,
+                    fontSize: 16,
+                    width: double.infinity,
+                    text: 'Add to Cart',
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+    },
+  );
+}

--- a/lib/components/product_widgets/product_grid_item.dart
+++ b/lib/components/product_widgets/product_grid_item.dart
@@ -11,6 +11,8 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
+import 'modal_size_selector.dart';
+
 
 class ProductGridItem extends StatelessWidget {
   final Product product;
@@ -20,10 +22,10 @@ class ProductGridItem extends StatelessWidget {
     required this.product,
   });
 
+
+
   @override
   Widget build(BuildContext context) {
-    final productService = ProductService();
-    productService.getImageUrl(product.imageUrl);
     final colorScheme = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
 
@@ -33,82 +35,127 @@ class ProductGridItem extends StatelessWidget {
           context.push('/shop/product', extra: product);
         },
 
-    child: Card(
-      color: colorScheme.surface,
-      elevation: 2,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(0),
-      ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Product Image
-            AspectRatio(
-              aspectRatio: 1,
-              child: ClipRRect(
-                borderRadius: const BorderRadius.vertical(top: Radius.circular(0)),
-                child: buildProductImage(context, product.imageUrl, product.imagePath),
-              ),
-            ),
-
-            // Product Details
-            Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+        child: Card(
+          color: colorScheme.surface,
+          elevation: 2,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(0),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Product Image
+              Stack(
                 children: [
-                  Text(
-                    product.name,
-                    style: textTheme.bodyMedium?.copyWith(
-                      color: colorScheme.textPrimary,
-                      fontWeight: FontWeight.bold,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-
-                  Text(
-                    formatPrice(product.price),
-                    style: textTheme.bodyMedium?.copyWith(
-                      color: colorScheme.accent,
+                  AspectRatio(
+                    aspectRatio: 1,
+                    child: ClipRRect(
+                      borderRadius: const BorderRadius.vertical(
+                          top: Radius.circular(0)),
+                      child: buildProductImage(
+                          context, product.imageUrl, product.imagePath),
                     ),
                   ),
 
-                  // Action Buttons
-                  Row(
-                    children: [
-                      // Add to Cart Button
-                      Expanded(
-                        child: AddToCartButton(
-                          onTap: () {
-                            context.read<Shop>().addToCart(product);
-                            DialogService.showAddToCartDialog(context, product);
-                          },
-                          height: 30,
-                          fontSize: 10,
-                        ),
+                  // Wishlist Icon
+                  Positioned(
+                    top: 8,
+                    right: 8,
+                    child: Container(
+                      width: 25,
+                      height: 25,
+                      decoration: BoxDecoration(
+                        color: Colors.transparent,
+                        shape: BoxShape.circle,
                       ),
-
-                      const SizedBox(width: 8),
-
-                      // Add to Wishlist Button
-                      CustomIconButton(
-                        icon: Icons.favorite_border,
-                        onTap: () {
+                      child: IconButton(
+                        icon: const Icon(
+                          Icons.favorite_border, color: Colors.white,),
+                        color: Theme.of(context).primaryColor,
+                        onPressed: () {
                           context.read<Shop>().addToWishlist(product);
-                          DialogService.showAddToWishlistDialog(context, product);
+                          DialogService.showAddToWishlistDialog(
+                              context, product);
                         },
-                        size: 30,
-                        iconSize: 16,
+                        constraints: const BoxConstraints.tightFor(
+                            width: 25, height: 25),
+                        padding: EdgeInsets.zero,
+                        iconSize: 20,
                       ),
-                    ],
+                    ),
                   ),
                 ],
               ),
-            ),
-          ],
-        ),
-      ),
+
+              // Product Details
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+
+                    //Product Info
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            product.name,
+                            style: textTheme.bodyMedium?.copyWith(
+                              color: colorScheme.textPrimary,
+                              fontWeight: FontWeight.bold,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+
+                          Text(
+                            formatPrice(product.price),
+                            style: textTheme.bodyMedium?.copyWith(
+                              color: colorScheme.accent,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+
+                    // Add to Cart Button
+                    /*Expanded(
+                      child: AddToCartButton(
+                        onTap: () {
+                          context.read<Shop>().addToCart(product);
+                          DialogService.showAddToCartDialog(context, product);
+                        },
+                        height: 30,
+                        fontSize: 10,
+                      ),
+                    ),*/
+
+                    // Add to Cart Icon
+                    Container(
+                      width: 25,
+                      height: 25,
+                      margin: const EdgeInsets.only(right: 0, top: 8),
+                      child: IconButton(
+                        icon: Icon(
+                          Icons.shopping_bag_outlined,
+                          color: colorScheme.primary,
+                          size: 20,
+                        ),
+                        onPressed: () => showSizeSelectorModal(context, product),
+                        constraints: const BoxConstraints.tightFor(
+                            width: 25, height: 25),
+                        padding: EdgeInsets.zero,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        )
     );
   }
 }

--- a/lib/components/product_widgets/product_page_size_selector.dart
+++ b/lib/components/product_widgets/product_page_size_selector.dart
@@ -21,17 +21,6 @@ class SizeSelector extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          "Choose Size",
-          style: TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.bold,
-            color: textColor,
-          ),
-        ),
-
-        const SizedBox(height: 12),
-
         Row(
           children: sizes.map((size) {
             final isSelected = selectedSize == size;

--- a/lib/components/product_widgets/quantity_selector.dart
+++ b/lib/components/product_widgets/quantity_selector.dart
@@ -6,12 +6,14 @@ class QuantitySelector extends StatelessWidget {
   final int quantity;
   final VoidCallback onIncrement;
   final VoidCallback onDecrement;
+  final double size;
 
   const QuantitySelector({
     Key? key,
     required this.quantity,
     required this.onIncrement,
     required this.onDecrement,
+    this.size = 25,
   }) : super(key: key);
 
   @override
@@ -20,19 +22,22 @@ class QuantitySelector extends StatelessWidget {
     final textColor = colorScheme.primary;
 
     return Row(
+      mainAxisSize: MainAxisSize.min,
       children: [
         CustomIconButton(
           icon: Icons.remove,
           onTap: onDecrement,
           iconColor: textColor,
           borderColor: textColor,
+          size: size,
+          iconSize: size * 0.6,
         ),
         Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+          padding: EdgeInsets.symmetric(horizontal: size * 0.3),
           child: Text(
             quantity.toString(),
             style: TextStyle(
-              fontSize: 18,
+              fontSize: size * 0.6,
               fontWeight: FontWeight.bold,
               color: textColor,
             ),
@@ -43,6 +48,8 @@ class QuantitySelector extends StatelessWidget {
           onTap: onIncrement,
           iconColor: textColor,
           borderColor: textColor,
+          size: size,
+          iconSize: size * 0.6,
         ),
       ],
     );

--- a/lib/models/products_model.dart
+++ b/lib/models/products_model.dart
@@ -12,6 +12,7 @@ class Product {
   final bool isFeatured;
   final int quantity;
   final Map<String, dynamic>? additionalInfo;
+  final String? selectedSize;
 
   Product({
     required this.id,
@@ -27,11 +28,11 @@ class Product {
     this.isFeatured = false,
     this.quantity = 1, // Default quantity
     this.additionalInfo,
+    this.selectedSize,
   });
 
   // Factory constructor to create a Product from JSON
   factory Product.fromJson(Map<String, dynamic> json) {
-
     return Product(
       id: json['product_id'].toString(),
       name: json['name'] ?? '',
@@ -40,12 +41,47 @@ class Product {
       categoryId: json['category_id'] ?? '',
       isActive: json['is_active'],
       createdAt: DateTime.parse(json['created_at']),
-      updatedAt: json['updated_at'] != null ? DateTime.parse(json['updated_at']) : null,
+      updatedAt: json['updated_at'] != null
+          ? DateTime.parse(json['updated_at'])
+          : null,
       imageUrl: json['image_url'] ?? '',
       imagePath: json['image_url'] ?? '',
       isFeatured: json['is_featured'] ?? false,
       quantity: json['quantity'] ?? 1,
       additionalInfo: json['additional_info'],
+    );
+  }
+
+  Product copyWith({
+    String? id,
+    String? name,
+    double? price,
+    String? description,
+    String? categoryId,
+    bool? isActive,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    String? imageUrl,
+    String? imagePath,
+    bool? isFeatured,
+    int? quantity,
+    String? selectedSize,
+  }) {
+    return Product(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      price: price ?? this.price,
+      description: description ?? this.description,
+      categoryId: categoryId ?? this.categoryId,
+      isActive: isActive ?? this.isActive,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      imageUrl: imageUrl ?? this.imageUrl,
+      imagePath: imagePath ?? this.imagePath,
+      isFeatured: isFeatured ?? this.isFeatured,
+      quantity: quantity ?? this.quantity,
+      additionalInfo: additionalInfo ?? this.additionalInfo,
+      selectedSize: selectedSize ?? this.selectedSize,
     );
   }
 
@@ -62,23 +98,4 @@ class Product {
       'image_url': imageUrl,
     };
   }
-
-  // Create a copy of this product with a new quantity
-  Product copyWith({int? quantity}) {
-    return Product(
-      id: id,
-      name: name,
-      price: price,
-      description: description,
-      categoryId: categoryId,
-      isActive: isActive,
-      createdAt: createdAt,
-      imageUrl: imageUrl,
-      imagePath: imagePath,
-      isFeatured: isFeatured,
-      quantity: quantity ?? this.quantity,
-      additionalInfo: additionalInfo,
-    );
-  }
 }
-

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -241,7 +241,7 @@ class _HomePageState extends State<HomePage> {
                 },
               ),
 
-              const SizedBox(height: 30),
+              const SizedBox(height: 15),
 
               // Newsletter Section
               NewsletterSection(

--- a/lib/pages/product_detail_page.dart
+++ b/lib/pages/product_detail_page.dart
@@ -4,7 +4,7 @@ import 'package:bid/components/product_widgets/color_selector.dart';
 import 'package:bid/components/product_widgets/main_product_image.dart';
 import 'package:bid/components/product_widgets/product_details_section.dart';
 import 'package:bid/components/product_widgets/quantity_selector.dart';
-import 'package:bid/components/product_widgets/size_selector.dart';
+import 'package:bid/components/product_widgets/product_page_size_selector.dart';
 import 'package:bid/services/product_service.dart';
 import 'package:flutter/material.dart';
 import 'package:bid/models/products_model.dart';
@@ -23,20 +23,13 @@ class ProductDetailPage extends StatefulWidget {
 
 class _ProductDetailPageState extends State<ProductDetailPage> {
   int quantity = 1;
-  String? selectedSize;
+  String selectedSize = 'M';
   String? selectedColor;
   bool isAccessory = false;
   bool isLoading = true;
   final ProductService _productService = ProductService();
 
-  // Available sizes
-  final List<String> sizes = ['S', 'M', 'L', 'XL'];
-
-  final List<Color> colors = [
-    Colors.black,
-    Colors.white70,
-    Colors.grey.shade700,
-  ];
+  final List<String> sizes = ['XS', 'S', 'M', 'L', 'XL'];
 
   @override
   void initState() {
@@ -52,6 +45,7 @@ class _ProductDetailPageState extends State<ProductDetailPage> {
 
     setState(() {
       isAccessory = result;
+      isLoading = false;
     });
   }
 
@@ -108,16 +102,7 @@ class _ProductDetailPageState extends State<ProductDetailPage> {
                       description: widget.product.description,
                     ),
 
-                    const SizedBox(height: 24),
-
-                    // Quantity Selector
-                    QuantitySelector(
-                      quantity: quantity,
-                      onIncrement: _incrementQuantity,
-                      onDecrement: _decrementQuantity,
-                    ),
-
-                    const SizedBox(height: 24),
+                    const SizedBox(height: 20),
 
                     // Size Selection
                   if (!isLoading && !isAccessory) ...[
@@ -127,8 +112,17 @@ class _ProductDetailPageState extends State<ProductDetailPage> {
                         onSizeSelected: _selectSize,
                       ),
 
-                      const SizedBox(height: 24),
-                    ],
+                      const SizedBox(height: 20),
+
+                    // Quantity Selector
+                    QuantitySelector(
+                      quantity: quantity,
+                      onIncrement: _incrementQuantity,
+                      onDecrement: _decrementQuantity,
+                    ),
+                  ],
+
+                    const SizedBox(height: 20),
 
                     // Color Selection
                     /*ColorSelector(
@@ -143,6 +137,7 @@ class _ProductDetailPageState extends State<ProductDetailPage> {
                     AddToCartSection(
                       product: widget.product,
                       quantity: quantity,
+                      selectedSize: selectedSize,
                     ),
                   ],
                 ),

--- a/lib/providers/shop_provider.dart
+++ b/lib/providers/shop_provider.dart
@@ -7,7 +7,9 @@ class Shop extends ChangeNotifier {
   final List<Product> _wishlist = [];
 
   List<Product> get shop => _shop;
+
   List<Product> get cart => _cart;
+
   List<Product> get wishlist => _wishlist;
 
   // Update shop list with products from Supabase
@@ -23,7 +25,8 @@ class Shop extends ChangeNotifier {
 
   void addToCart(Product product) {
     // Check if product already exists in cart
-    final existingIndex = _cart.indexWhere((item) => item.id == product.id);
+    final existingIndex = _cart.indexWhere((item) =>
+    item.id == product.id && item.selectedSize == product.selectedSize);
 
     if (existingIndex >= 0) {
       // If product exists, increase quantity
@@ -40,20 +43,33 @@ class Shop extends ChangeNotifier {
   }
 
   void removeFromCart(Product product) {
-    _cart.removeWhere((item) => item.id == product.id);
-    notifyListeners();
-  }
-
-  void addToWishlist(Product product) {
-    if (!_wishlist.any((item) => item.id == product.id)) {
-      _wishlist.add(product);
+    final existingIndex = _cart.indexWhere(
+            (item) =>
+        item.id == product.id && item.selectedSize == product.selectedSize
+    );
+    if (existingIndex >= 0) {
+      final existingProduct = _cart[existingIndex];
+      if (existingProduct.quantity > 1) {
+        _cart[existingIndex] = existingProduct.copyWith(
+            quantity: existingProduct.quantity - 1
+        );
+      }
+      else {
+        _cart.removeAt(existingIndex);
+      }
       notifyListeners();
     }
   }
 
-  void removeFromWishlist(Product product) {
-    _wishlist.removeWhere((item) => item.id == product.id);
-    notifyListeners();
-  }
-}
+    void addToWishlist(Product product) {
+      if (!_wishlist.any((item) => item.id == product.id)) {
+        _wishlist.add(product);
+        notifyListeners();
+      }
+    }
 
+    void removeFromWishlist(Product product) {
+      _wishlist.removeWhere((item) => item.id == product.id);
+      notifyListeners();
+    }
+  }

--- a/lib/utils/page_helpers.dart
+++ b/lib/utils/page_helpers.dart
@@ -52,7 +52,7 @@ Widget buildProductGrid(
     child: GridView.builder(
       gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
         crossAxisCount: 2,
-        childAspectRatio: 0.6,
+        childAspectRatio: 0.75,
         crossAxisSpacing: 10,
         mainAxisSpacing: 10,
       ),


### PR DESCRIPTION
- Size selector modal pops up on product grid and wishlist items that are added to cart
- Size selector in main product page now connected to shop and sizes updated in cart
- General styling of addtocart button applied throughout
- Small modification to categories to display as uppercase
- Modification to product grid item to have a cart icon for the addtocart, and a favourites icon for add to wishlist
- Slight modification to text colours on homepage photos to stay the same rather than change in light/dark mode, since they will be on the same photo and need to have the same visibility

Customers can now add a specific size to their cart.  Decision made to remove colour selector since items will only be available in one colour